### PR TITLE
Updated GM struct for PropertySelectQuery

### DIFF
--- a/utils/captureviewer.pyw
+++ b/utils/captureviewer.pyw
@@ -487,7 +487,7 @@ class CaptureViewer(viewer.Viewer):
 						property["ownerName"] = packet.read(str, length_type=c_uint)
 						property["name"] = packet.read(str, length_type=c_uint)
 						property["description"] = packet.read(str, length_type=c_uint)
-						property["reputation"] = packet.read(c_uint)
+						property["reputation"] = packet.read(c_float)
 						property["isBff"] = packet.read(c_bit)
 						property["isFriend"] = packet.read(c_bit)
 						property["isModeratedApproved"] = packet.read(c_bit)
@@ -495,7 +495,8 @@ class CaptureViewer(viewer.Viewer):
 						property["isOwned"] = packet.read(c_bit)
 						property["accessType"] = packet.read(c_uint)
 						property["dateLastPublished"] = packet.read(c_uint)
-						property["performanceCost"] = packet.read(c_uint64)
+						property["performanceIndex???"] = packet.read(c_uint)
+						property["performanceCost"] = packet.read(c_float)
 
 						properties.append(property)
 


### PR DESCRIPTION
Reputation is for some reason sent as a float (always ending in .0?) and performance cost is a float after a uint32_t.  
Attached is a screenshot of what the new packet capture looks like with the updated values.
![image](https://user-images.githubusercontent.com/39972741/161000961-536092a0-1f42-4057-8f91-6f0da77c9b08.png)
