### PR TITLE
Add pet hardcoded component removals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+
+.DS_Store
+*.pcap
+*.zip
+*.tmp
+*.pyc
+utils/captureviewer.ini

--- a/utils/captureviewer.pyw
+++ b/utils/captureviewer.pyw
@@ -131,6 +131,7 @@ class CaptureViewer(viewer.Viewer):
 		self.retry_with_script_component = BooleanVar(value=config["parse"]["retry_with_script_component"])
 		self.retry_with_trigger_component = BooleanVar(value=config["parse"]["retry_with_trigger_component"])
 		self.retry_with_phantom_component = BooleanVar(value=config["parse"]["retry_with_phantom_component"])
+		self.default_capture_path = config["paths"]["default_capture_path"]
 
 	def _create_parsers(self):
 		type_handlers = {}
@@ -176,7 +177,7 @@ class CaptureViewer(viewer.Viewer):
 		self.tree.tag_configure("error", foreground="red")
 
 	def askopener(self):
-		return filedialog.askopenfilenames(filetypes=[("Zip", "*.zip")], initialdir=".")
+		return filedialog.askopenfilenames(filetypes=[("Zip", "*.zip")], initialdir=self.default_capture_path)
 
 	def load(self, captures) -> None:
 		self.objects = []

--- a/utils/captureviewer.pyw
+++ b/utils/captureviewer.pyw
@@ -267,6 +267,10 @@ class CaptureViewer(viewer.Viewer):
 				if 3 in component_types:
 					component_types.remove(3)
 
+			if 26 in component_types:
+				component_types.remove(42)
+				component_types.remove(11)
+
 			parsers = OrderedDict()
 			try:
 				component_types.sort(key=comp_ids.index)

--- a/utils/captureviewer.pyw
+++ b/utils/captureviewer.pyw
@@ -176,7 +176,7 @@ class CaptureViewer(viewer.Viewer):
 		self.tree.tag_configure("error", foreground="red")
 
 	def askopener(self):
-		return filedialog.askopenfilenames(filetypes=[("Zip", "*.zip")])
+		return filedialog.askopenfilenames(filetypes=[("Zip", "*.zip")], initialdir=".")
 
 	def load(self, captures) -> None:
 		self.objects = []

--- a/utils/viewer.py
+++ b/utils/viewer.py
@@ -1,6 +1,6 @@
 from tkinter import BOTH, BOTTOM, END, HORIZONTAL, LEFT, Menu, NSEW, RIGHT, StringVar, Text, TOP, X, Y
 from tkinter.font import nametofont
-from tkinter.ttk import Entry, Frame, Label, PanedWindow, Progressbar, Scrollbar, Style, Treeview
+from tkinter.ttk import Entry, Frame, Label, Panedwindow, Progressbar, Scrollbar, Style, Treeview
 
 class Viewer(Frame):
 	def __init__(self):
@@ -22,14 +22,17 @@ class Viewer(Frame):
 
 	def create_widgets(self, create_inspector: bool=True) -> None:
 		self.menubar = Menu()
-		self.menubar.add_command(label="Open", command=self._askopen)
+		open_menu = Menu()
+		open_menu.add_command(label="Open", command=self._askopen, accelerator="Ctrl+O")
 		self.master.config(menu=self.menubar)
+		self.menubar.add_cascade(label="View", menu=open_menu)
 
 		find_entry = Entry(textvariable=self.find_input)
 		find_entry.pack(fill=X)
 		find_entry.bind("<Return>", self._find)
 
-		pane = PanedWindow(orient=HORIZONTAL)
+		pane = Panedwindow(orient=HORIZONTAL, width=self.winfo_screenwidth(), height=self.winfo_screenheight())
+		
 		pane.pack(fill=BOTH, expand=True)
 
 		frame = Frame()


### PR DESCRIPTION
![image](https://github.com/lcdr/utils/assets/39972741/191f9434-ccbe-4c4a-b9b6-01b6dbfa2d85)
![image](https://github.com/lcdr/utils/assets/39972741/382e3cea-39dc-470c-8396-c354f518422f)

Client has hard coded checks to remove these.  Doing so fixes de-serialization of pets.  See `Grandmaster Clang Panda training course(named the Panda Chewy)` for proof of the fix